### PR TITLE
Remove source_date routine

### DIFF
--- a/voters/create_voter_tables.sql
+++ b/voters/create_voter_tables.sql
@@ -14,7 +14,6 @@ ALTER TABLE "voters_voter" ALTER COLUMN "mname" DROP NOT NULL;
 ALTER TABLE "voters_voter" ALTER COLUMN "party" DROP NOT NULL;
 ALTER TABLE "voters_voter" ALTER COLUMN "phone" DROP NOT NULL;
 ALTER TABLE "voters_voter" ALTER COLUMN "race" DROP NOT NULL;
-ALTER TABLE "voters_voter" ALTER COLUMN "source_date" DROP NOT NULL;
 ALTER TABLE "voters_voter" ALTER COLUMN "suffix" DROP NOT NULL;
 ALTER TABLE "voters_voter" ALTER COLUMN "zip" DROP NOT NULL;
 COMMIT;

--- a/voters/load_county_voters.py
+++ b/voters/load_county_voters.py
@@ -10,8 +10,8 @@ import requests
 from dateutil import parser
 from django.template.defaultfilters import slugify
 
-# SET VOTER_DATA_DATE to the date on the voter disk
-VOTER_DATA_DATE = datetime.datetime(2020, 7, 7).date()
+# SET VOTER_DATA_DATE to the date on the voter disk, defaulting to today.
+VOTER_DATA_DATE = datetime.date.today()
 if os.getenv('VOTER_DATA_DATE'):
     VOTER_DATA_DATE = parser.parse(os.getenv('VOTER_DATA_DATE')).date()
 
@@ -342,14 +342,10 @@ def prep_files():
 
 def load_to_postgres():
     db = get_postgres_db_name()
-    set_date_command = (
-        'echo "ALTER TABLE voters_voter ALTER COLUMN source_date '
-        'SET DEFAULT \'{}\';" | psql {}'.format(VOTER_DATA_DATE, db))
     if db not in subprocess.getoutput('psql -l'):
         subprocess.run('createdb {}'.format(db), shell=True)
         subprocess.run(
             'psql {} -f create_voter_tables.sql'.format(db), shell=True)
-    subprocess.run(set_date_command, shell=True)
     for each in no_dotfiles(LOADBASE):
         slug = each[:3]
         if slug in FL_COUNTIES:

--- a/voters/models.py
+++ b/voters/models.py
@@ -96,7 +96,6 @@ class Voter(models.Model):
     email = models.CharField(max_length=255, blank=True, null=True)
     voter_id = models.CharField(max_length=255, blank=True, null=True)
     county_slug = models.CharField(max_length=255, blank=True, null=True)
-    source_date = models.DateField(max_length=255, blank=True, null=True)
 
     class Meta:
         ordering = ['lname', 'fname']


### PR DESCRIPTION
The previous load script added a `source_date` column on every row in the voter database, which was wasteful because it was the same value across the entire database.

We can derive the source date from the database name, so we can drop this column.